### PR TITLE
Init

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2017 Busbud
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,21 @@
+# gitbook-plugin-link-targets
+
+Straight forward plugin that adds `target` attributes to links that contain the keys set in the config. This allows you
+to have other resources live in the same subdirectory of gitbook.
+
+__Example:__
+
+The following will now have all links containing `subpages` to open in a new window.
+
+```json
+{
+  "plugins": ["link-targets"],
+  "pluginsConfig": {
+    "link-targets": {
+      "targets": {
+        "subpages": "_blank"
+      }
+    }
+  }
+}
+```

--- a/book/plugin.js
+++ b/book/plugin.js
@@ -1,0 +1,13 @@
+require(['gitbook', 'jquery'], function(gitbook, $) {
+  function addTargets() {
+    var targets = gitbook.state.config.pluginsConfig['link-targets'].targets;
+    var keys = Object.keys(targets);
+    keys.forEach(function(key) {
+      $('a[href*="'+ key + '"]').each(function(idx, el) {
+        $(el).attr('target', targets[key]);
+      });
+    });
+  }
+
+  gitbook.events.bind('page.change', addTargets);
+});

--- a/index.js
+++ b/index.js
@@ -1,0 +1,6 @@
+module.exports = {
+  book: {
+    assets: './book',
+    js: ['plugin.js']
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "gitbook-plugin-link-targets",
+  "version": "0.0.1",
+  "description": "Adds targets to links containing the keys set in config",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "Busbud",
+  "license": "MIT",
+  "engines": {
+    "gitbook": "*"
+  },
+  "gitbook": {
+    "properties": {
+      "targets": {
+        "type": "object",
+        "default": {},
+        "title": "Targets to add to matching urls containing the keys of the config"
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Overview

Straight forward plugin that adds `target` attributes to links that contain the keys set in the config. This allows you to have other resources live in the same subdirectory of gitbook.